### PR TITLE
fix: next/image has been replaced with next/legacy/image

### DIFF
--- a/components/BadgeID_Comp.js
+++ b/components/BadgeID_Comp.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import { Spacer } from "@chakra-ui/react";
 import html2canvas from "html2canvas";
 import axios from "axios";

--- a/components/PopupBanner.js
+++ b/components/PopupBanner.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import Link from "next/link";
 
 const PopupBanner = ({ onClose }) => {

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import Link from "next/link";
 import React, { useState } from "react";
 

--- a/pages/jobfair.js
+++ b/pages/jobfair.js
@@ -9,7 +9,7 @@ import EllipseBox2 from "../components/BgAssets/EllipseBox2";
 import EllipseBox from "../components/BgAssets/EllipseBox";
 import SmallHex from "../components/BgAssets/SmallHex";
 import SocialFollow from "../components/homepage/SocialFollow";
-import Image from "next/image";
+import Image from "next/legacy/image";
 
 function Faq() {
   const [data] = useState(accordionData);

--- a/pages/leaderboard.js
+++ b/pages/leaderboard.js
@@ -16,7 +16,7 @@ import { faList } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTheme } from "next-themes";
 import Head from "next/head";
-import Image from "next/image";
+import Image from "next/legacy/image";
 import { Tooltip } from "react-tooltip";
 import React, { useCallback, useEffect, useState } from "react";
 import Confetti from "react-confetti";


### PR DESCRIPTION
**Description:**

Starting with Next.js 13, the next/image component was rewritten to improve both the performance and developer experience. In order to provide a backwards compatible upgrade solution, the old next/image was renamed to next/legacy/image.

Due to this,we had missing images from pages which used next/image,this pr fixes it by replacing them with next/legacy/images

**Screenshots -** 

**Bug:**

![Screenshot (685)](https://github.com/user-attachments/assets/976d9b1d-7f59-4ae0-949a-cdc52e062035)
![Screenshot (687)](https://github.com/user-attachments/assets/bbbca7f3-e383-4cbe-a4fc-78b135cddef5)

**Fixed:**

![Screenshot (690)](https://github.com/user-attachments/assets/c27f3e44-7897-4017-a4bc-9ab60dcbfde3)
![Screenshot (689)](https://github.com/user-attachments/assets/af582ce7-c7c2-441a-95e8-f1fc94da9836)

**Additional Context:**

N/A